### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server implementation in pure Node.js that provides a fun tool to generate random US State and signature soup combinations.
 
+<a href="https://glama.ai/mcp/servers/@gbti-network/mcp-basic-test">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gbti-network/mcp-basic-test/badge" alt="Super Secret Server MCP server" />
+</a>
+
 ## Features
 
 - Pure Node.js implementation


### PR DESCRIPTION
This PR adds a badge for the [Super Secret MCP Server](https://glama.ai/mcp/servers/@gbti-network/mcp-basic-test) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gbti-network/mcp-basic-test">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gbti-network/mcp-basic-test/badge" alt="Super Secret Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.